### PR TITLE
Improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ edition = "2021"
 clap = { version = "4.1", features = ["derive"] }
 chrono = "0.4"
 colored = "2.0"
+anyhow = "1.0"


### PR DESCRIPTION
I've refactored the code to have a cleaner error handling, with a single `anyhow::Error` gathering all the possible errors and displaying them accordingly.
By doing so, we have less duplicated code fragments and an overall cleaner code.

@RealIndrit feel free to review the code.
